### PR TITLE
Removed .inverse from emergency level

### DIFF
--- a/src/outputs/console.js
+++ b/src/outputs/console.js
@@ -11,7 +11,7 @@ const STYLES = {
   error: { method: 'error', levelColor: chalk.red },
   critical: { method: 'error', levelColor: chalk.red.underline },
   alert: { method: 'error', levelColor: chalk.red.bold },
-  emergency: { method: 'error', levelColor: chalk.red.bold.inverse }
+  emergency: { method: 'error', levelColor: chalk.red.bold }
 };
 
 export class ConsoleOutput {


### PR DESCRIPTION
We included universal-log in code that is loaded in IE, and there it breaks on `chalk.red.bold.inverse`. used for emergency log messages. I removed the `.inverse` and then it works fine.